### PR TITLE
Next.js Migrate to App Layout

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,13 @@
+export default function RootLayout({
+  // Layouts must accept a children prop.
+  // This will be populated with nested layouts or pages
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function Page() {
+  return <h1>Hello, TSE</h1>;
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 export default function Page() {
   return <h1>Hello, TSE</h1>;
 }

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,5 +1,0 @@
-import type { AppProps } from "next/app";
-
-export default function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
-}

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,3 +1,0 @@
-export default function ExamplePage() {
-  return <h1>Hello, TSE</h1>;
-}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,11 +1,7 @@
 import type { Config } from "tailwindcss";
 
 export default {
-  content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
-  ],
+  content: ["./src/components/**/*.{js,ts,jsx,tsx,mdx}", "./src/app/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Changes

Migrating Next app to the new `app` layout instead of `pages`. This will allow us to leverage updated Next.js optimization steps, which enables the TSE constellations package.

[Migration Documentation](https://nextjs.org/docs/pages/building-your-application/upgrading/app-router-migration#step-4-migrating-pages).
[Next.js App Documentation](https://nextjs.org/docs/app/getting-started)

Instead of keeping a `src/pages` directory, all pages should be created in the `src/app` directory.
``` 
src
|__ app
    |__ MY_NEW_PAGE
    |   |__ ...
    |   |__ page.tsx (MY_NEW_PAGE entry point)
    |__ ...
    |__ layout.tsx (root layout)
    |__ page.tsx (root entry point)
```


