### PR TITLE
Mobile layout for box links

### DIFF
--- a/frontend/src/components/BoxLink.tsx
+++ b/frontend/src/components/BoxLink.tsx
@@ -17,11 +17,11 @@ export function BoxLink({
   link: link,
 }: BoxLinkProps) {
   let contStyle =
-    'group relative overflow-hidden cursor-pointer flex after:content-[""] after:absolute after:bottom-[0] after:left-[0] after:w-[0] after:h-[6px] after:bg-blue-500 after:transition-all after:duration-300 after:ease-in-out after:z-20 hover:after:w-full before:content-[""] before:absolute before:top-[0] before:left-[0] before:w-full before:h-full before:bg-[rgba(0,_0,_0,_0.5)] before:z-10 hover:before:bg-[rgba(0,_0,_0,_0.2)]';
+    'group relative overflow-hidden cursor-pointer flex md:flex-row w-full h-[400px] after:content-[""] after:absolute after:bottom-[0] after:left-[0] after:w-[0] after:h-[6px] after:bg-blue-500 after:transition-all after:duration-300 after:ease-in-out after:z-20 hover:after:w-full before:content-[""] before:absolute before:top-[0] before:left-[0] before:w-full before:h-full before:bg-[rgba(0,_0,_0,_0.5)] before:z-10 hover:before:bg-[rgba(0,_0,_0,_0.2)]';
   if (isTall) {
-    contStyle += " h-[598px]";
+    contStyle += " md:h-[598px]";
   } else {
-    contStyle += " h-[539px]";
+    contStyle += " md:h-[539px]";
   }
 
   return (
@@ -34,7 +34,7 @@ export function BoxLink({
         />
         <div
           className={
-            'absolute left-0 bottom-0 w-full h-[186px] pl-[24px] pr-[24px] pb-[40px] text-[#f9f9f9] font-["GolosText"] z-20 text-left justify-between flex-col'
+            'absolute left-0 bottom-0 w-full h-2/3 md:h-[186px] pl-[24px] pr-[24px] pb-[40px] text-[#f9f9f9] font-["GolosText"] z-20 text-left justify-between flex-col'
           }
         >
           <div className={"mb-auto"}>

--- a/frontend/src/components/BoxLinkGroup.tsx
+++ b/frontend/src/components/BoxLinkGroup.tsx
@@ -4,7 +4,7 @@ import { BoxLink } from "./BoxLink";
 
 const BoxLinkGroup = () => {
   return (
-    <div className="w-full h-[662px] grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] flex-wrap items-end">
+    <div className="w-full flex-col md:grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] flex-wrap items-end">
       <BoxLink
         tall={false}
         src={


### PR DESCRIPTION
## Tracking Info

Resolves #73 

## Changes

<!-- What changes did you make? -->

- Add mobile/tablet box link layout

## Testing

<!-- How did you confirm your changes worked? -->

- Tested different device sizes to test responsiveness

NOTE: When testing this, I recommend commenting out the header as the header text is too large for mobile and causes empty space.

## Confirmation of Change

<!-- Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change. -->

![image](https://github.com/user-attachments/assets/59921c1a-1be5-4aeb-9cb2-fc6221b178ff)

